### PR TITLE
Fix SurrealDB peer runtime identity

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,13 +6,16 @@
       "name": "@surrealdb/better-auth",
       "dependencies": {
         "better-auth": "^1.6.9",
-        "surrealdb": "^2.0.3",
       },
       "devDependencies": {
         "@better-auth/test-utils": "^1.6.9",
         "@biomejs/biome": "^2.4.14",
         "@types/node": "^25.6.0",
+        "surrealdb": "^2.0.3",
         "vitest": "^4.1.5",
+      },
+      "peerDependencies": {
+        "surrealdb": "^2.0.3",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -13,20 +13,23 @@
 	},
 	"files": ["dist"],
 	"scripts": {
-		"build": "bun build ./src/index.ts --outdir dist --target node && tsc -p tsconfig.build.json --emitDeclarationOnly",
+		"build": "bun build ./src/index.ts --outdir dist --target node --packages external && tsc -p tsconfig.build.json --emitDeclarationOnly",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome lint src/",
 		"format": "biome format --write src/"
 	},
 	"dependencies": {
-		"better-auth": "^1.6.9",
+		"better-auth": "^1.6.9"
+	},
+	"peerDependencies": {
 		"surrealdb": "^2.0.3"
 	},
 	"devDependencies": {
 		"@better-auth/test-utils": "^1.6.9",
 		"@biomejs/biome": "^2.4.14",
 		"@types/node": "^25.6.0",
+		"surrealdb": "^2.0.3",
 		"vitest": "^4.1.5"
 	}
 }


### PR DESCRIPTION
This PR fixes a runtime class identity issue in the published adapter build.

The adapter source imports `RecordId` from `surrealdb`, but the current Bun build can bundle dependencies into `dist/index.js`. That means the published adapter can contain a private bundled copy of SurrealDB's runtime classes.

A consuming app also imports `surrealdb` for its own `Surreal` client. Even when both copies are the same package version, they are separate JavaScript class identities:

```text
adapter bundled RecordId !== app RecordId
```

The adapter creates a record id for the Surreal row id slot:

```ts
new RecordId("user", id)
```

But if that `RecordId` comes from the adapter's bundled copy, the app's Surreal client may not recognize it as its own `RecordId` class when encoding query bindings. The malformed binding can create rows like:

```text
user:{ }
```

instead of:

```text
user:⟨uuid⟩
```

## Before

```text
@surrealdb/better-auth/dist/index.js
  └─ bundled surrealdb
      └─ RecordId class B

consumer app
  └─ node_modules/surrealdb
      ├─ Surreal client
      └─ RecordId class A

adapter creates RecordId class B
app client expects RecordId class A
class identity mismatch
query binding encodes incorrectly
```

```mermaid
flowchart TD
    BA["Better Auth"]
    Adapter["@surrealdb/better-auth dist"]
    Bundled["bundled surrealdb copy<br/>RecordId class B"]
    AppClient["consumer app surrealdb<br/>Surreal client + RecordId class A"]
    DB["SurrealDB"]
    Bad["created row:<br/>user:{ }"]

    BA -->|"id = UUID string"| Adapter
    Adapter -->|"new RecordId('user', id)"| Bundled
    Bundled -->|"RecordId class B"| AppClient
    AppClient -->|"does not recognize class B"| DB
    DB --> Bad

    style Bad fill:#ffd6d6,stroke:#aa0000,color:#000
```

## After

```text
@surrealdb/better-auth/dist/index.js
  └─ import { RecordId } from "surrealdb"

consumer app
  └─ node_modules/surrealdb
      ├─ Surreal client
      └─ RecordId class A

adapter imports RecordId class A
app client expects RecordId class A
class identity matches
query binding encodes correctly
```

```mermaid
flowchart TD
    BA["Better Auth"]
    Adapter["@surrealdb/better-auth dist"]
    AppRuntime["consumer app surrealdb<br/>Surreal client + RecordId class A"]
    DB["SurrealDB"]
    Good["created row:<br/>user:⟨uuid⟩"]

    Adapter -->|"import { RecordId } from 'surrealdb'"| AppRuntime
    BA -->|"id = UUID string"| Adapter
    Adapter -->|"new RecordId('user', id)<br/>using class A"| AppRuntime
    AppRuntime -->|"recognized RecordId"| DB
    DB --> Good

    style Good fill:#d8ffd8,stroke:#008a00,color:#000
```

## Why both changes are needed

This PR makes two packaging changes:

```json
"build": "bun build ./src/index.ts --outdir dist --target node --packages external && tsc -p tsconfig.build.json --emitDeclarationOnly"
```

and:

```json
"peerDependencies": {
  "surrealdb": "^2.0.3"
}
```

`--packages external` keeps `surrealdb` as an external import in `dist/index.js` instead of bundling it.

`peerDependencies.surrealdb` ensures the adapter does not install or own a nested SurrealDB runtime and instead uses the consumer app's installed `surrealdb`.

Together they preserve the invariant:

```text
adapter RecordId === app Surreal client RecordId
```

`peerDependencies` alone is not enough if `dist/index.js` already contains bundled SurrealDB code.

`--packages external` alone is not enough if the adapter can still install a nested `node_modules/surrealdb` copy.

## Id semantics

This does not change Better Auth id semantics.

Better Auth-facing ids remain strings:

```ts
user.id
session.userId
account.userId
verification.identifier
```

Only the SurrealDB intrinsic row id slot is converted to `RecordId` at query time:

```ts
row.id
```

Correct flow:

```text
Better Auth generateId -> string UUID
adapter create user row -> RecordId("user", uuid) only for Surreal row.id
SurrealDB stores -> user:⟨uuid⟩
adapter returns -> string UUID back to Better Auth
```

## Summary

The source logic using `new RecordId(...)` is not the bug by itself. The bug is when that `RecordId` comes from a bundled/private copy of `surrealdb` instead of the same `surrealdb` runtime used by the consuming app's `Surreal` client.

This PR fixes that by externalizing package imports during build and making `surrealdb` a peer dependency.